### PR TITLE
Use FastGaussQuadrature in place of QuadGK

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -27,6 +27,7 @@ julia = "1.4"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+QuadGK = "1fd47b50-473d-5c70-9696-f719f8f3bcdc"
 
 [targets]
-test = ["Test"]
+test = ["Test", "QuadGK"]

--- a/examples/thermo.jl
+++ b/examples/thermo.jl
@@ -35,11 +35,9 @@ end
 function g_kinetic(I, km::KineticModel; Ω=Ω, muoA=muoA, muoB=muoB, T=T)
     thermo_term(x) = g_thermo(x; Ω=Ω, muoA=muoA, muoB=muoB, T=T)
     function kinetic_term(x, w, n)
-        # f(x) = ElectrochemicalKinetics.fit_overpotential_t( (1 .- x) .* Ref(km), I, 0.1)
         f(x) = ElectrochemicalKinetics.fit_overpotential( (1 .- x) .* Ref(km), I, true)
         map((w, n) -> sum(w .* f(n)), eachcol(w), eachcol(n))
     end
-    # g(x::AbstractVector) = thermo_term(x) .+ kinetic_term(x)
     g(x, w, n) = thermo_term(x) .+ kinetic_term(x, w, n)
     return g
 end
@@ -56,8 +54,6 @@ end
 function common_tangent(x::Array, I, km::KineticModel; nodes, weights, kwargs...)
     g = g_kinetic(I, km; kwargs...)
     µ = µ_kinetic(I, km; kwargs...)
-    # w1, n1 = ElectrochemicalKinetics.scale_integration_nodes(zeros.(x[:, 1]), x[:, 1])
-    # w2, n2 = ElectrochemicalKinetics.scale_integration_nodes(zero.(x[:, 2]), x[:, 2])
     w1, n1 = weights[:, 1], nodes[:, 1]
     w2, n2 = weights[:, 2], nodes[:, 2]
     Δg = g(x[:,2], w2, n2) - g(x[:,1], w1, n1)

--- a/examples/thermo.jl
+++ b/examples/thermo.jl
@@ -1,7 +1,6 @@
 using ElectrochemicalKinetics
 using Plots
 using NLsolve
-# using QuadGK
 using FastGaussQuadrature
 
 # define some constants and default parameters

--- a/examples/thermo.jl
+++ b/examples/thermo.jl
@@ -38,6 +38,7 @@ function g_kinetic(I, km::KineticModel; Ω=Ω, muoA=muoA, muoB=muoB, T=T)
         map((w, n) -> sum(w .* f(n)), eachcol(w), eachcol(n))
     end
     g(x, w, n) = thermo_term(x) .+ kinetic_term(x, w, n)
+    g(x::Real, w, n) = thermo_term(x) + kinetic_term(x, w, n)[1]
     return g
 end
 

--- a/src/ElectrochemicalKinetics.jl
+++ b/src/ElectrochemicalKinetics.jl
@@ -19,6 +19,7 @@ export compute_k, compute_k_cq
 
 include("fitting.jl")
 # include("datastructures.jl")
+include("integration_utils.jl")
 export fitting_params, fit_model, fit_overpotential, is_dosmodel
 
 include("plot_fcns.jl")

--- a/src/integration_utils.jl
+++ b/src/integration_utils.jl
@@ -1,9 +1,26 @@
 using FastGaussQuadrature
 
 # helper function to be able to "naturally" use the interval of integration that we want with FastGaussQuadrature, which returns nodes and weights for the interval [-1, 1] (see https://en.wikipedia.org/wiki/Gaussian_quadrature#Change_of_interval)
-function get_nodes_weights(lb, ub; N=1000,  quadfun=gausslegendre)
-    unscaled_x, unscaled_w = quadfun(N)
-    w = 0.5 * (ub - lb) * unscaled_w
-    x = 0.5 * (ub + lb) + 0.5 * (ub - lb) * unscaled_x
-    w, x
+function scale_integration_nodes(unscaled_x, unscaled_w, lb::Real, ub::Real)
+    w = @. 0.5 * (ub - lb) * unscaled_w
+    x = @. 0.5 * (ub + lb) + 0.5 * (ub - lb) * unscaled_x
+    x, w
 end
+
+function scale_integration_nodes(unscaled_x, unscaled_w, lb, ub)
+	# @show lb, ub
+    ns_and_ws = scale_integration_nodes.(Ref(unscaled_x), Ref(unscaled_w), lb, ub)
+    ns, ws = Zygote.unzip(ns_and_ws)
+    reduce(hcat, ns), reduce(hcat, ws)
+end
+
+
+# Can't get this to broadcast correctly - but this is the right sort of
+# approach to take here. Of note - this is 2x faster in the forwards pass
+# and about 10x faster in the backwards pass compared to the other method
+# function scale_integration_nodes2(unscaled_x, unscaled_w, lb, ub)
+#     w_scale = @. 0.5 * (ub - lb)
+#     x_scale = @. 0.5 * (ub + lb) + 0.5 * (ub - lb)
+#     unscaled_x * x_scale', unscaled_w * w_scale'
+#     # x_scale * unscaled_x, unscaled_w * w_scale'
+# end

--- a/test/integral_model_tests.jl
+++ b/test/integral_model_tests.jl
@@ -22,7 +22,7 @@
         # test that a uniform DOS version matches MHC
         flat_dos = [-5 1; 5 1]
         mhcd = MarcusHushChidseyDOS(0.25, flat_dos)
-        @test isapprox(compute_k(0, mhcd), 0.0, atol=1e-16)
+        @test isapprox(compute_k(0, mhcd), 0.0, atol=1e-6)
         mhc = MarcusHushChidsey(0.25)
         mhcd_k = compute_k(Vs, mhcd)
         mhc_k = compute_k(Vs, mhc)
@@ -35,7 +35,7 @@
         dos = hcat(Es, gaussian.(0.7 .*(Es .- 2)) .+ gaussian.(0.7 .*(Es .+ 2)))
         mhcd = MarcusHushChidseyDOS(0.25, dos)
         # this should be symmetric
-        @test all(isapprox.(compute_k(Vs, mhcd), compute_k(-Vs, mhcd), atol=1e-15))
+        @test all(isapprox.(compute_k(Vs, mhcd), compute_k(-Vs, mhcd), atol=1e-6))
         # now try an asymmetric one
         dos = hcat(Es .+ 1, dos[:,2])
         mhcd = MarcusHushChidseyDOS(0.25, dos)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,5 @@
 using ElectrochemicalKinetics
+using QuadGK
 using Test
 
 @testset "ElectrochemicalKinetics.jl" begin

--- a/test/thermo_tests.jl
+++ b/test/thermo_tests.jl
@@ -99,13 +99,13 @@ unscaled_x, unscaled_w = quadfun(N)
 
             # integral of the derivative should be the original fcn (up to a constant, which we know)
             integrated_μs = [v[1] for v in quadgk.(μ_50, zero(xs), xs)]
-            @test g_50(xs, weights_xs, nodes_xs) ≈ integrated_μs .+ muoA
+            @test all(isapprox.(g_50(xs, weights_xs, nodes_xs), integrated_μs .+ muoA, atol=1e-6))
 
             # check scalar input works
             @test g_50(xs[2], weights_xs[:, 2], nodes_xs[:, 2]) == g_50(xs, weights_xs, nodes_xs)[2] ≈ g_50_2_vals[typeof(km)]
 
             # check a few other values
-            @test g_200_T400(xs, weights_xs, nodes_xs) ≈ g_200_T400_vals[typeof(km)]
+            @test all(isapprox.(g_200_T400(xs, weights_xs, nodes_xs), g_200_T400_vals[typeof(km)], atol=1e-6))
         end
     end
 end
@@ -122,9 +122,9 @@ end
                                                                      v1)             # ub
     common_tangent_def(args...; kwargs...) = common_tangent(args...; nodes = nodes, weights = weights, kwargs...)
 
-    @test all(isapprox.(common_tangent_def(v1, 100, km), Ref(0.0), atol=1e-8)) # not sure why this one doesnt converge as closely as the rest
+    @test all(isapprox.(common_tangent_def(v1, 100, km), Ref(0.0), atol=1e-6)) # not sure why this one doesnt converge as closely as the rest
     v2 = find_phase_boundaries(100, km, T=350)
-    @test all(isapprox.(common_tangent_def(v2, 100, km, T=350), Ref(0.0), atol=1e-11))
+    @test all(isapprox.(common_tangent_def(v2, 100, km, T=350), Ref(0.0), atol=1e-6))
     # they should get "narrower" with temperature
     @test v2[1] > v1[1]
     @test v2[2] < v1[2]

--- a/test/thermo_tests.jl
+++ b/test/thermo_tests.jl
@@ -99,13 +99,14 @@ unscaled_x, unscaled_w = quadfun(N)
 
             # integral of the derivative should be the original fcn (up to a constant, which we know)
             integrated_μs = [v[1] for v in quadgk.(μ_50, zero(xs), xs)]
-            @test all(isapprox.(g_50(xs, weights_xs, nodes_xs), integrated_μs .+ muoA, atol=1e-6))
+            @test all(isapprox.(g_50(xs, weights_xs, nodes_xs), integrated_μs .+ muoA, atol=1e-5))
 
             # check scalar input works
-            @test g_50(xs[2], weights_xs[:, 2], nodes_xs[:, 2]) == g_50(xs, weights_xs, nodes_xs)[2] ≈ g_50_2_vals[typeof(km)]
+            @test g_50(xs[2], weights_xs[:, 2], nodes_xs[:, 2]) == g_50(xs, weights_xs, nodes_xs)[2] 
+            @test isapprox(g_50(xs, weights_xs, nodes_xs)[2], g_50_2_vals[typeof(km)], atol=1e-5)
 
             # check a few other values
-            @test all(isapprox.(g_200_T400(xs, weights_xs, nodes_xs), g_200_T400_vals[typeof(km)], atol=1e-6))
+            @test all(isapprox.(g_200_T400(xs, weights_xs, nodes_xs), g_200_T400_vals[typeof(km)], atol=1e-5))
         end
     end
 end
@@ -117,14 +118,18 @@ end
     v1 = find_phase_boundaries(100, km)
 
     nodes, weights = ElectrochemicalKinetics.scale_integration_nodes(unscaled_x,     # nodes
-                                                                     unscaled_w,     # weights
-                                                                     zero.(v1),      # lb
-                                                                     v1)             # ub
+                            unscaled_w,     # weights
+                            zero.(v1),      # lb
+                            v1)             # ub
     common_tangent_def(args...; kwargs...) = common_tangent(args...; nodes = nodes, weights = weights, kwargs...)
 
-    @test all(isapprox.(common_tangent_def(v1, 100, km), Ref(0.0), atol=1e-6)) # not sure why this one doesnt converge as closely as the rest
+    @test all(isapprox.(common_tangent_def(v1, 100, km), Ref(0.0), atol=1e-6))
     v2 = find_phase_boundaries(100, km, T=350)
-    @test all(isapprox.(common_tangent_def(v2, 100, km, T=350), Ref(0.0), atol=1e-6))
+    nodes, weights = ElectrochemicalKinetics.scale_integration_nodes(unscaled_x,     # nodes
+                            unscaled_w,     # weights
+                            zero.(v1),      # lb
+                            v2)             # ub
+    @test all(isapprox.(common_tangent_def(v2, 100, km, T=350), Ref(0.0), atol=1e-5))
     # they should get "narrower" with temperature
     @test v2[1] > v1[1]
     @test v2[2] < v1[2]

--- a/test/thermo_tests.jl
+++ b/test/thermo_tests.jl
@@ -79,6 +79,10 @@ xs = [0.1, 0.5, 0.95]
     end
 end
 
+# Set up the integrator for `common_tangent` using defaults as in the thermo example
+unscaled_x, unscaled_w = quadfun(N)
+
+
 @testset "Kinetic g" begin
     g_200_T400_vals = Dict(
         ButlerVolmer => [0.0205857425, 0.037693617, 0.06661696], 
@@ -86,6 +90,7 @@ end
         AsymptoticMarcusHushChidsey => [0.0207838185, 0.0390031065, 0.0729910686]
         )
     g_50_2_vals = Dict(ButlerVolmer=>0.03519728018258, Marcus=>0.03395267141265, AsymptoticMarcusHushChidsey=>0.0347968044)
+    nodes_xs, weights_xs = ElectrochemicalKinetics.scale_integration_nodes(unscaled_x, unscaled_w, zero.(xs), xs)
     for km in kms
         @testset "$(typeof(km))" begin
             μ_50 = μ_kinetic(50, km)
@@ -94,24 +99,32 @@ end
 
             # integral of the derivative should be the original fcn (up to a constant, which we know)
             integrated_μs = [v[1] for v in quadgk.(μ_50, zero(xs), xs)]
-            @test g_50(xs) ≈ integrated_μs .+ muoA
+            @test g_50(xs, weights_xs, nodes_xs) ≈ integrated_μs .+ muoA
 
             # check scalar input works
-            @test g_50(xs[2]) == g_50(xs)[2] ≈ g_50_2_vals[typeof(km)]
+            @test g_50(xs[2], weights_xs[:, 2], nodes_xs[:, 2]) == g_50(xs, weights_xs, nodes_xs)[2] ≈ g_50_2_vals[typeof(km)]
 
             # check a few other values
-            @test g_200_T400(xs) ≈ g_200_T400_vals[typeof(km)]
+            @test g_200_T400(xs, weights_xs, nodes_xs) ≈ g_200_T400_vals[typeof(km)]
         end
     end
 end
 
 @testset "Phase Diagram" begin
     km = bv # TODO: expand this
+
     # simplest case, just one pair of x values (this function is still pretty slow though)
     v1 = find_phase_boundaries(100, km)
-    @test all(isapprox.(common_tangent(v1, 100, km), Ref(0.0), atol=1e-8)) # not sure why this one doesnt converge as closely as the rest
+
+    nodes, weights = ElectrochemicalKinetics.scale_integration_nodes(unscaled_x,     # nodes
+                                                                     unscaled_w,     # weights
+                                                                     zero.(v1),      # lb
+                                                                     v1)             # ub
+    common_tangent_def(args...; kwargs...) = common_tangent(args...; nodes = nodes, weights = weights, kwargs...)
+
+    @test all(isapprox.(common_tangent_def(v1, 100, km), Ref(0.0), atol=1e-8)) # not sure why this one doesnt converge as closely as the rest
     v2 = find_phase_boundaries(100, km, T=350)
-    @test all(isapprox.(common_tangent(v2, 100, km, T=350), Ref(0.0), atol=1e-11))
+    @test all(isapprox.(common_tangent_def(v2, 100, km, T=350), Ref(0.0), atol=1e-11))
     # they should get "narrower" with temperature
     @test v2[1] > v1[1]
     @test v2[2] < v1[2]

--- a/test/thermo_tests.jl
+++ b/test/thermo_tests.jl
@@ -127,7 +127,7 @@ end
     v2 = find_phase_boundaries(100, km, T=350)
     nodes, weights = ElectrochemicalKinetics.scale_integration_nodes(unscaled_x,     # nodes
                             unscaled_w,     # weights
-                            zero.(v1),      # lb
+                            zero.(v2),      # lb
                             v2)             # ub
     @test all(isapprox.(common_tangent_def(v2, 100, km, T=350), Ref(0.0), atol=1e-5))
     # they should get "narrower" with temperature


### PR DESCRIPTION
Preliminary tests show that the integrals converge (albeit with slight deviations from QuadGK - see CI failures).

Most notably, this is pretty quick

```julia
julia> @btime quadgk.(x -> ElectrochemicalKinetics.fit_overpotential((1 .- x) .* Ref($bv), $(I_vals[1]), 0.1), 0., .8)
  2.526 s (27394300 allocations: 3.17 GiB)
(0.00041825235722375246, 6.171612093559286e-12)

julia> @btime begin
         w, x = get_nodes_weights(0, 0.8)
         sum(w .* $f(x))
       end
  39.622 ms (1127518 allocations: 134.23 MiB)
0.000419099395501497
```

where `bv` and `I_vals` are taken from `examples/thermo.jl`. 