### PR TITLE
RFC: simpler API for integration

### DIFF
--- a/examples/thermo.jl
+++ b/examples/thermo.jl
@@ -35,7 +35,7 @@ function g_kinetic(I, km::KineticModel; Ω=Ω, muoA=muoA, muoB=muoB, T=T)
     thermo_term(x) = g_thermo(x; Ω=Ω, muoA=muoA, muoB=muoB, T=T)
     function kinetic_term(x)
         f(x) = ElectrochemicalKinetics.fit_overpotential( (1 .- x) .* Ref(km), I, true)
-        w, n = ElectrochemicalKinetics.scale(x)
+        n, w = ElectrochemicalKinetics.scale(x)
         map((w, n) -> sum(w .* f(n)), eachcol(w), eachcol(n))
     end
     g(x) = thermo_term(x) .+ kinetic_term(x)

--- a/examples/thermo.jl
+++ b/examples/thermo.jl
@@ -35,7 +35,7 @@ function g_kinetic(I, km::KineticModel; Ω=Ω, muoA=muoA, muoB=muoB, T=T)
     thermo_term(x) = g_thermo(x; Ω=Ω, muoA=muoA, muoB=muoB, T=T)
     function kinetic_term(x)
         f(x) = ElectrochemicalKinetics.fit_overpotential( (1 .- x) .* Ref(km), I, true)
-        n, w = ElectrochemicalKinetics.scale(x)
+        n, w = ElectrochemicalKinetics.scale(zero.(x), x)
         map((w, n) -> sum(w .* f(n)), eachcol(w), eachcol(n))
     end
     g(x) = thermo_term(x) .+ kinetic_term(x)

--- a/examples/thermo.jl
+++ b/examples/thermo.jl
@@ -33,30 +33,29 @@ function µ_kinetic(I, km::KineticModel; Ω=Ω, muoA=muoA, muoB=muoB, T=T)
 end
 function g_kinetic(I, km::KineticModel; Ω=Ω, muoA=muoA, muoB=muoB, T=T)
     thermo_term(x) = g_thermo(x; Ω=Ω, muoA=muoA, muoB=muoB, T=T)
-    function kinetic_term(x, w, n)
+    function kinetic_term(x)
         f(x) = ElectrochemicalKinetics.fit_overpotential( (1 .- x) .* Ref(km), I, true)
+        w, n = ElectrochemicalKinetics.scale(x)
         map((w, n) -> sum(w .* f(n)), eachcol(w), eachcol(n))
     end
-    g(x, w, n) = thermo_term(x) .+ kinetic_term(x, w, n)
-    g(x::Real, w, n) = thermo_term(x) + kinetic_term(x, w, n)[1]
+    g(x) = thermo_term(x) .+ kinetic_term(x)
+    g(x::Real) = thermo_term(x) + kinetic_term(x)[1]
     return g
 end
 
 # zeros of this function correspond to pairs of x's satisfying the common tangent condition for a given µ function
 # case where we just feed in two points (x should be of length two)
-function common_tangent(x::Vector, I, km::KineticModel; Ω=Ω, muoA=muoA, muoB=muoB, T=T, nodes, weights)
+function common_tangent(x::Vector, I, km::KineticModel; Ω=Ω, muoA=muoA, muoB=muoB, T=T)
     g = g_kinetic(I, km; Ω=Ω, muoA=muoA, muoB=muoB, T=T)
     µ = µ_kinetic(I, km; Ω=Ω, muoA=muoA, muoB=muoB, T=T)
-    [(g(x[2], weights, nodes) - g(x[1], weights, nodes))/(x[2] - x[1]) .- μ(x[1]), μ(x[2])-μ(x[1])]
+    [(g(x[2]) - g(x[1]))/(x[2] - x[1]) .- μ(x[1]), μ(x[2])-μ(x[1])]
 end
 
 # case where we want to check many points at once (shape of x should be N x 2)
-function common_tangent(x::Array, I, km::KineticModel; nodes, weights, kwargs...)
+function common_tangent(x::Array, I, km::KineticModel; kwargs...)
     g = g_kinetic(I, km; kwargs...)
     µ = µ_kinetic(I, km; kwargs...)
-    w1, n1 = weights[:, 1], nodes[:, 1]
-    w2, n2 = weights[:, 2], nodes[:, 2]
-    Δg = g(x[:,2], w2, n2) - g(x[:,1], w1, n1)
+    Δg = g(x[:,2]) - g(x[:,1])
     Δx = x[:,2] - x[:,1]
     μ1 = μ(x[:,1])
     Δμ = μ(x[:,2]) - μ1
@@ -64,14 +63,9 @@ function common_tangent(x::Array, I, km::KineticModel; nodes, weights, kwargs...
 end
 
 function find_phase_boundaries(I, km::KineticModel; quadfun=quadfun, N=N, kwargs...)
-    unscaled_x, unscaled_w = quadfun(N)
     
     function myct!(storage, x)
-        nodes, weights = ElectrochemicalKinetics.scale_integration_nodes(unscaled_x,    # nodes
-                                                                         unscaled_w,    # weights
-                                                                         zero.(x),      # lb
-                                                                         x)             # ub
-        res = common_tangent(x, I, km; nodes = nodes, weights = weights, kwargs...)
+        res = common_tangent(x, I, km; kwargs...)
         storage[1] = res[1]
         storage[2] = res[2]
     end

--- a/examples/thermo.jl
+++ b/examples/thermo.jl
@@ -38,7 +38,7 @@ function g_kinetic(I, km::KineticModel; Ω=Ω, muoA=muoA, muoB=muoB, T=T)
         n, w = ElectrochemicalKinetics.scale(zero.(x), x)
         map((w, n) -> sum(w .* f(n)), eachcol(w), eachcol(n))
     end
-    g(x) = thermo_term(x) .+ kinetic_term(x)
+    g(x) = thermo_term(x) .+ kinetic_term(vec(x))
     g(x::Real) = thermo_term(x) + kinetic_term(x)[1]
     return g
 end

--- a/src/integration_utils.jl
+++ b/src/integration_utils.jl
@@ -9,14 +9,28 @@ function setup_integration(f, N)
         x = @. 0.5 * (ub + lb) + 0.5 * (ub - lb) * nodes
         x, w
     end
-    function scale(lb, ub, nodes = nodes, weights = weights)
+    function scale(lb::T, ub::T, nodes = nodes, weights = weights) where T <: AbstractVector
         ns_and_ws = scale.(lb, ub, Ref(nodes), Ref(weights))
-        ns, ws = Zygote.unzip(ns_and_ws)
+        ns, ws = Zygote.unzip(ns_and_ws)::Vector{Tuple{T, T}}
         reduce(hcat, ns), reduce(hcat, ws)
     end
 end
 
 const scale = setup_integration(gausslegendre, 1000)
+
+# const nodes, weights = gausslegendre(1000)
+# function scale(lb::Real, ub::Real, nodes = nodes, weights = weights)
+#     # use nodes and weights here
+#     w = @. 0.5 * (ub - lb) * weights
+#     x = @. 0.5 * (ub + lb) + 0.5 * (ub - lb) * nodes
+#     x, w
+# end
+# function scale(lb::AbstractVector, ub::AbstractVector, nodes::AbstractVector = nodes, weights::AbstractVector = weights)
+#     ns_and_ws = scale.(lb, ub, Ref(nodes), Ref(weights))
+#     @show typeof(ns_and_ws)
+#     ns, ws = Zygote.unzip(ns_and_ws)::Vector{Tuple{Vector{Float64}, Vector{Float64}}}
+#     reduce(hcat, ns), reduce(hcat, ws)
+# end
 
 # Can't get this to broadcast correctly - but this is the right sort of
 # approach to take here. Of note - this is 2x faster in the forwards pass

--- a/src/integration_utils.jl
+++ b/src/integration_utils.jl
@@ -18,20 +18,6 @@ end
 
 const scale = setup_integration(gausslegendre, 1000)
 
-# const nodes, weights = gausslegendre(1000)
-# function scale(lb::Real, ub::Real, nodes = nodes, weights = weights)
-#     # use nodes and weights here
-#     w = @. 0.5 * (ub - lb) * weights
-#     x = @. 0.5 * (ub + lb) + 0.5 * (ub - lb) * nodes
-#     x, w
-# end
-# function scale(lb::AbstractVector, ub::AbstractVector, nodes::AbstractVector = nodes, weights::AbstractVector = weights)
-#     ns_and_ws = scale.(lb, ub, Ref(nodes), Ref(weights))
-#     @show typeof(ns_and_ws)
-#     ns, ws = Zygote.unzip(ns_and_ws)::Vector{Tuple{Vector{Float64}, Vector{Float64}}}
-#     reduce(hcat, ns), reduce(hcat, ws)
-# end
-
 # Can't get this to broadcast correctly - but this is the right sort of
 # approach to take here. Of note - this is 2x faster in the forwards pass
 # and about 10x faster in the backwards pass compared to the other method

--- a/src/integration_utils.jl
+++ b/src/integration_utils.jl
@@ -11,7 +11,7 @@ function setup_integration(f, N)
     end
     function scale(lb::T, ub::T, nodes = nodes, weights = weights) where T <: AbstractVector
         ns_and_ws = scale.(lb, ub, Ref(nodes), Ref(weights))
-        ns, ws = Zygote.unzip(ns_and_ws)::Vector{Tuple{T, T}}
+        ns, ws = Zygote.unzip(ns_and_ws)::Tuple{Vector{T}, Vector{T}}
         reduce(hcat, ns), reduce(hcat, ws)
     end
 end

--- a/src/integration_utils.jl
+++ b/src/integration_utils.jl
@@ -1,18 +1,6 @@
 using FastGaussQuadrature
 
 # helper function to be able to "naturally" use the interval of integration that we want with FastGaussQuadrature, which returns nodes and weights for the interval [-1, 1] (see https://en.wikipedia.org/wiki/Gaussian_quadrature#Change_of_interval)
-function scale_integration_nodes(unscaled_x, unscaled_w, lb::Real, ub::Real)
-    w = @. 0.5 * (ub - lb) * unscaled_w
-    x = @. 0.5 * (ub + lb) + 0.5 * (ub - lb) * unscaled_x
-    x, w
-end
-
-function scale_integration_nodes(unscaled_x, unscaled_w, lb, ub)
-    ns_and_ws = scale_integration_nodes.(Ref(unscaled_x), Ref(unscaled_w), lb, ub)
-    ns, ws = Zygote.unzip(ns_and_ws)
-    reduce(hcat, ns), reduce(hcat, ws)
-end
-
 function setup_integration(f, N)
     nodes, weights = f(N)
     function scale(lb::Real, ub::Real, nodes, weights)

--- a/src/integration_utils.jl
+++ b/src/integration_utils.jl
@@ -1,20 +1,19 @@
-using FastGaussQuadrature
+using FastGaussQuadrature: gausslegendre
 
 # helper function to be able to "naturally" use the interval of integration that we want with FastGaussQuadrature, which returns nodes and weights for the interval [-1, 1] (see https://en.wikipedia.org/wiki/Gaussian_quadrature#Change_of_interval)
 function setup_integration(f, N)
     nodes, weights = f(N)
-    function scale(lb::Real, ub::Real, nodes, weights)
+    function scale(lb::Real, ub::Real, nodes = nodes, weights = weights)
         # use nodes and weights here
         w = @. 0.5 * (ub - lb) * weights
         x = @. 0.5 * (ub + lb) + 0.5 * (ub - lb) * nodes
         x, w
     end
-    function scale(lb, ub)
+    function scale(lb, ub, nodes = nodes, weights = weights)
         ns_and_ws = scale.(lb, ub, Ref(nodes), Ref(weights))
         ns, ws = Zygote.unzip(ns_and_ws)
         reduce(hcat, ns), reduce(hcat, ws)
     end
-    scale(lb::Real, ub::Real) = scale(lb, ub, nodes, weights)
 end
 
 const scale = setup_integration(gausslegendre, 1000)

--- a/test/integration.jl
+++ b/test/integration.jl
@@ -1,0 +1,14 @@
+@testset "Integration" begin
+  lb, ub = 0.1, 0.2
+  nodes, weights = ElectrochemicalKinetics.scale(lb, ub)
+  @test nodes[1] ≈ lb atol = 1e-5
+  @test nodes[end] ≈ ub atol = 1e-5
+
+  lb = rand(2)
+  ub = lb .+ rand.()
+
+  nodes, weights = ElectrochemicalKinetics.scale(lb, ub)
+  @test nodes isa Matrix
+  @test nodes[1, :] ≈ lb atol = 1e-5
+  @test nodes[end, :] ≈ ub atol = 1e-5
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -16,4 +16,8 @@ using Test
     @testset "Thermo" begin
         include("thermo_tests.jl")
     end
+
+    @testset "Integration" begin
+        include("integration.jl")
+    end
 end

--- a/test/thermo_tests.jl
+++ b/test/thermo_tests.jl
@@ -86,7 +86,6 @@ end
         AsymptoticMarcusHushChidsey => [0.0207838185, 0.0390031065, 0.0729910686]
         )
     g_50_2_vals = Dict(ButlerVolmer=>0.03519728018258, Marcus=>0.03395267141265, AsymptoticMarcusHushChidsey=>0.0347968044)
-    nodes_xs, weights_xs = ElectrochemicalKinetics.scale(zero.(xs), xs)
     for km in kms
         @testset "$(typeof(km))" begin
             μ_50 = μ_kinetic(50, km)
@@ -113,13 +112,10 @@ end
     # simplest case, just one pair of x values (this function is still pretty slow though)
     v1 = find_phase_boundaries(100, km)
 
-    nodes, weights = ElectrochemicalKinetics.scale(zero.(v1), v1)
-    common_tangent_def(args...; kwargs...) = common_tangent(args...; nodes = nodes, weights = weights, kwargs...)
-
-    @test all(isapprox.(common_tangent_def(v1, 100, km), Ref(0.0), atol=1e-6))
+    @test all(isapprox.(common_tangent(vec(v1), 100, km), Ref(0.0), atol=1e-6))
     v2 = find_phase_boundaries(100, km, T=350)
     nodes, weights = ElectrochemicalKinetics.scale(vec(zero.(v2)), vec(v2))
-    @test all(isapprox.(common_tangent_def(v2, 100, km, T=350), Ref(0.0), atol=1e-5))
+    @test all(isapprox.(common_tangent(vec(v2), 100, km, T=350), Ref(0.0), atol=1e-5))
     # they should get "narrower" with temperature
     @test v2[1] > v1[1]
     @test v2[2] < v1[2]

--- a/test/thermo_tests.jl
+++ b/test/thermo_tests.jl
@@ -112,10 +112,10 @@ end
     # simplest case, just one pair of x values (this function is still pretty slow though)
     v1 = find_phase_boundaries(100, km)
 
-    @test all(isapprox.(common_tangent(vec(v1), 100, km), Ref(0.0), atol=1e-6))
+    @test all(isapprox.(common_tangent(v1, 100, km), Ref(0.0), atol=1e-6))
     v2 = find_phase_boundaries(100, km, T=350)
     nodes, weights = ElectrochemicalKinetics.scale(vec(zero.(v2)), vec(v2))
-    @test all(isapprox.(common_tangent(vec(v2), 100, km, T=350), Ref(0.0), atol=1e-5))
+    @test all(isapprox.(common_tangent(v2, 100, km, T=350), Ref(0.0), atol=1e-5))
     # they should get "narrower" with temperature
     @test v2[1] > v1[1]
     @test v2[2] < v1[2]

--- a/test/thermo_tests.jl
+++ b/test/thermo_tests.jl
@@ -79,10 +79,6 @@ xs = [0.1, 0.5, 0.95]
     end
 end
 
-# Set up the integrator for `common_tangent` using defaults as in the thermo example
-unscaled_x, unscaled_w = quadfun(N)
-
-
 @testset "Kinetic g" begin
     g_200_T400_vals = Dict(
         ButlerVolmer => [0.0205857425, 0.037693617, 0.06661696], 
@@ -90,7 +86,7 @@ unscaled_x, unscaled_w = quadfun(N)
         AsymptoticMarcusHushChidsey => [0.0207838185, 0.0390031065, 0.0729910686]
         )
     g_50_2_vals = Dict(ButlerVolmer=>0.03519728018258, Marcus=>0.03395267141265, AsymptoticMarcusHushChidsey=>0.0347968044)
-    nodes_xs, weights_xs = ElectrochemicalKinetics.scale_integration_nodes(unscaled_x, unscaled_w, zero.(xs), xs)
+    nodes_xs, weights_xs = ElectrochemicalKinetics.scale(zero.(xs), xs)
     for km in kms
         @testset "$(typeof(km))" begin
             μ_50 = μ_kinetic(50, km)
@@ -117,18 +113,12 @@ end
     # simplest case, just one pair of x values (this function is still pretty slow though)
     v1 = find_phase_boundaries(100, km)
 
-    nodes, weights = ElectrochemicalKinetics.scale_integration_nodes(unscaled_x,     # nodes
-                            unscaled_w,     # weights
-                            zero.(v1),      # lb
-                            v1)             # ub
+    nodes, weights = ElectrochemicalKinetics.scale(zero.(v1), v1)
     common_tangent_def(args...; kwargs...) = common_tangent(args...; nodes = nodes, weights = weights, kwargs...)
 
     @test all(isapprox.(common_tangent_def(v1, 100, km), Ref(0.0), atol=1e-6))
     v2 = find_phase_boundaries(100, km, T=350)
-    nodes, weights = ElectrochemicalKinetics.scale_integration_nodes(unscaled_x,     # nodes
-                            unscaled_w,     # weights
-                            zero.(v2),      # lb
-                            v2)             # ub
+    nodes, weights = ElectrochemicalKinetics.scale(zero.(v2), v2)
     @test all(isapprox.(common_tangent_def(v2, 100, km, T=350), Ref(0.0), atol=1e-5))
     # they should get "narrower" with temperature
     @test v2[1] > v1[1]

--- a/test/thermo_tests.jl
+++ b/test/thermo_tests.jl
@@ -95,14 +95,14 @@ end
 
             # integral of the derivative should be the original fcn (up to a constant, which we know)
             integrated_μs = [v[1] for v in quadgk.(μ_50, zero(xs), xs)]
-            @test all(isapprox.(g_50(xs, weights_xs, nodes_xs), integrated_μs .+ muoA, atol=1e-5))
+            @test all(isapprox.(g_50(xs), integrated_μs .+ muoA, atol=1e-5))
 
             # check scalar input works
-            @test g_50(xs[2], weights_xs[:, 2], nodes_xs[:, 2]) == g_50(xs, weights_xs, nodes_xs)[2] 
-            @test isapprox(g_50(xs, weights_xs, nodes_xs)[2], g_50_2_vals[typeof(km)], atol=1e-5)
+            @test g_50(xs[2]) == g_50(xs)[2] 
+            @test isapprox(g_50(xs)[2], g_50_2_vals[typeof(km)], atol=1e-5)
 
             # check a few other values
-            @test all(isapprox.(g_200_T400(xs, weights_xs, nodes_xs), g_200_T400_vals[typeof(km)], atol=1e-5))
+            @test all(isapprox.(g_200_T400(xs), g_200_T400_vals[typeof(km)], atol=1e-5))
         end
     end
 end

--- a/test/thermo_tests.jl
+++ b/test/thermo_tests.jl
@@ -118,7 +118,7 @@ end
 
     @test all(isapprox.(common_tangent_def(v1, 100, km), Ref(0.0), atol=1e-6))
     v2 = find_phase_boundaries(100, km, T=350)
-    nodes, weights = ElectrochemicalKinetics.scale(zero.(v2), v2)
+    nodes, weights = ElectrochemicalKinetics.scale(vec(zero.(v2)), vec(v2))
     @test all(isapprox.(common_tangent_def(v2, 100, km, T=350), Ref(0.0), atol=1e-5))
     # they should get "narrower" with temperature
     @test v2[1] > v1[1]


### PR DESCRIPTION
This is somewhat what I was proposing for keeping the state local to its effects - namely in integration. Note that I don't think this (or `const nodes, weights = gausslegendre(1000)` for that matter) would Revise properly so any changes to the integration would require restarting the REPL. Another consideration is type stability. Here we default to Float64 but it would be nicer to get the types to be inferred based on user defined `lb` and `ub`.