### PR TITLE
Add `onlyfj!` API to `fit_overpotential`

### DIFF
--- a/benchmark/bench_suite.jl
+++ b/benchmark/bench_suite.jl
@@ -26,7 +26,7 @@ for km in ni_kms
     suite["rate constants"]["non-integral models"]["vector V"][modeltype] = @benchmarkable compute_k(0.01:0.01:0.2, $km) seconds=time_mult
 end
 
-mhc = MarcusHushChidsey(70000, 0.3)
+mhc = MarcusHushChidsey(70000, 0.3, 1.0)
 mhcd_flatdos = MarcusHushChidseyDOS(70000, 0.3, [-5 1; 5 1])
 mhcd_Cu = MarcusHushChidseyDOS(10000, 0.3, string(@__DIR__, "/../data/DOSes/Cu_111_dos.txt"))
 i_kms = [mhc, mhcd_flatdos, mhcd_Cu]

--- a/src/fitting.jl
+++ b/src/fitting.jl
@@ -2,8 +2,6 @@ using Zygote
 using Optim
 using NLsolve
 using LinearAlgebra
-using Optimisers
-using Flux
 
 # sum of squares loss in logarithmic coordinates
 log_loss(y, y_pred) = (log.(y) .- log.(y_pred)).^2

--- a/src/fitting.jl
+++ b/src/fitting.jl
@@ -25,14 +25,14 @@ function fit_overpotential(model::KineticModel, k, guess = fill(0.1, length(k));
                 F .= loss(k, compute_k(V, model; kT = kT, kwargs...))
             elseif F == nothing && !isnothing(J)
                 # TODO: we could speed up the case of scalar k's by dispatching to call gradient here instead
-                gs = Zygote.gradient(V) do V
+                gs = Zygote.gradient(V[1]) do V
                     Zygote.forwarddiff(V) do V
                         loss(k, compute_k(V, model; kT = kT, kwargs...)) |> sum
                     end
                 end[1]
                 J .= gs
             else
-                y, back = Zygote.pullback(V) do V
+                y, back = Zygote.pullback(V[1]) do V
                     Zygote.forwarddiff(V) do V
                         loss(k, compute_k(V, model; kT = kT, kwargs...)) |> sum
                     end


### PR DESCRIPTION
This avoids the calculation of the primal in the case we want both the primal and the gradients. Helpful for `IntegralModel` where the calculation of the primal can be expensive.