### PR TITLE
Numerics tweaks

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ElectrochemicalKinetics"
 uuid = "a2c6e634-85ca-418a-9c67-9b5417ce2d04"
 authors = ["Rachel Kurchin <rkurchin@cmu.edu>", "Holden Parks <hparks@andrew.cmu.edu>", "Dhairya Gandhi <dhairya@juliacomputing.com>"]
-version = "0.2.0"
+version = "0.2.1"
 
 [deps]
 DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"

--- a/src/fitting.jl
+++ b/src/fitting.jl
@@ -61,7 +61,7 @@ function overpotential(k, model::KineticModel; a_r=1.0, a_o=1.0, guess = 0.1, T 
         if verbose
             println("shortcutting full solve")
         end
-        return zeros(Float32, length(model))
+        return zeros(length(model))
     elseif any(k .== 0) # vector k with some zero elements, scalar model
         if verbose
             println("shortcutting part of solve")
@@ -102,7 +102,7 @@ function overpotential(k, model::KineticModel; a_r=1.0, a_o=1.0, guess = 0.1, T 
         Vs = nlsolve(compare_k!, guess, show_trace=verbose)
     end
     if !converged(Vs) && warn
-        @warn "Overpotential fit not fully converged...you may have fed in an unreachable reaction rate!"
+        @warn "Overpotential fit not fully converged for $k...you may have fed in an unreachable reaction rate!"
     end
     sol = Vs.zero
     sol_return = zero(guess)
@@ -154,7 +154,7 @@ const default_param_bounds = Dict(:A => (0.1, 50000), :λ => (0.01, 0.5), :α =>
 # Keyword Arguments
 Requirements differ by model type...
 * `ButlerVolmer`, `AsymptoticMarcusHushChidsey`, `Marcus`: none
-* `MarcusHushChidsey`: average_dos::Float32 OR dos::DOSData OR dos_file::String
+* `MarcusHushChidsey`: average_dos OR dos::DOSData OR dos_file::String
 * `MarcusHushChidseyDOS`: dos::DOSData OR dos_file
 Some are always options...
 * `param_bounds::Dict{Symbol,Any}`: ranges of guesses for relevant model parameters. (must include all necessary keys, but defaults to some sensible ranges if not provided, see `default_param_bounds`...note that you should provide this for faster fitting if you know bounds)
@@ -218,8 +218,8 @@ function _fit_model(
     #         s[i] = gs[i]
     #     end
     # end
-    lower = Float32.([param_bounds[p][1] for p in fitting_params(model_type)])
-    upper = Float32.([param_bounds[p][2] for p in fitting_params(model_type)])
+    lower = [param_bounds[p][1] for p in fitting_params(model_type)]
+    upper = [param_bounds[p][2] for p in fitting_params(model_type)]
     init_guess = 0.5 .* (lower .+ upper)
 
     # set optimisers based on the model type

--- a/src/fitting.jl
+++ b/src/fitting.jl
@@ -20,11 +20,11 @@ function janky_log_loss(y, y_pred)
     end
 end
 
-# helper fcn to make sure starting guess for `overpotential` has correct sign
+# helper fcn to make sure starting guess for `overpotential` has correct sign and to make things into nicely zippable vector inputs
 function _get_guess(init_guess, k, model, a_r, a_o)
     guess = init_guess
     max_l = max(length(k), length(model), length(a_r), length(a_o))
-    local k_check
+    local k_check, a_r_check, a_o_check
     if init_guess isa Real
         guess = fill(init_guess, max_l)
     else
@@ -45,7 +45,17 @@ function _get_guess(init_guess, k, model, a_r, a_o)
         guess[k .< 0 .&& guess .> 0] .= -1 * guess[k .< 0 .&& guess .> 0]
         k_check = k
     end
-    return guess, k_check
+    # NB: this assumes a_r and a_o are of the same type
+    if a_r isa Real
+        a_r_check = repeat([a_r], max_l)
+        a_o_check = repeat([a_o], max_l)
+    elseif a_r isa Vector
+        a_r_check = a_r
+        a_o_check = a_o
+        @assert length(a_r) == length(a_o)
+    end
+    @assert length(a_r_check) == length(k_check) == length(guess)
+    return guess, k_check, a_r_check, a_o_check
 end
 
 # TODO: support reaction direction flag here
@@ -58,40 +68,45 @@ NOTE that this currently only solves for net reaction rates.
 """
 function overpotential(k, model::KineticModel; a_r=1.0, a_o=1.0, guess = 0.1, T = 298, loss = janky_log_loss, autodiff = true, verbose=false, warn=true, lin_thresh=0.05, kwargs...)
     # wherever magnitude of k is small (less than lin_thresh * thermal voltage) we don't need to do the full solve...
-    guess, k_check = _get_guess(guess, k, model, a_r, a_o)
+    guess, k_check, a_r_check, a_o_check = _get_guess(guess, k, model, a_r, a_o)
     guess_solve = guess
     k_solve = k_check
 
-    inds_linearize = findall(abs.(k_check) .<= lin_thresh .* rate_constant(kB*T, model, a_r=a_r, a_o=a_o, T=T, kwargs...))
-    inds_keep = setdiff(1:length(k_check), inds_linearize)
+    inds_linearize = findall(abs.(k_check) .<= lin_thresh .* rate_constant(kB*T, model; a_r=a_r_check, a_o=a_o_check, T=T, kwargs...))
+
+    inds_solve = setdiff(1:length(k_check), inds_linearize)
+    a_r_solve = a_r_check
+    a_o_solve = a_o_check
     if length(inds_linearize) > 0
-        k_solve = k_solve[inds_keep]
-        guess_solve = guess[inds_keep]
+        k_solve = k_solve[inds_solve]
+        guess_solve = guess[inds_solve]
+        a_r_solve = a_r_check[inds_solve]
+        a_o_solve = a_o_check[inds_solve]
     end
 
     sol_return = zero(guess)
 
     if length(k_solve) > 0
         function compare_k!(storage, V)
-            storage .= loss(k, rate_constant(V, model; a_r=a_r, a_o=a_o, T = T, kwargs...))
+            storage .= loss(k, rate_constant(V, model; a_r=a_r_solve, a_o=a_o_solve, T = T, kwargs...))
         end
         Vs = if autodiff
             function myfun!(F, J, V)
                 # println("V=",V)
                 # println("loss=", loss(k, rate_constant(V, model; T=T, kwargs...)))
                 if isnothing(J)
-                    F .= loss(k_solve, rate_constant(V, model; a_r=a_r, a_o=a_o, T = T, kwargs...))
+                    F .= loss(k_solve, rate_constant(V, model; a_r=a_r_solve, a_o=a_o_solve, T = T, kwargs...))
                 elseif isnothing(F) && !isnothing(J)
                     gs = Zygote.gradient(V) do V
                         Zygote.forwarddiff(V) do V
-                            loss(k_solve, rate_constant(V, model; a_r=a_r, a_o=a_o, T = T, kwargs...)) |> sum
+                            loss(k_solve, rate_constant(V, model; a_r=a_r_solve, a_o=a_o_solve, T = T, kwargs...)) |> sum
                         end
                     end[1]
                     J .= diagm(gs)
                 else
                     y, back = Zygote.pullback(V) do V
                         Zygote.forwarddiff(V) do V
-                            loss(k_solve, rate_constant(V, model; a_r=a_r, a_o=a_o, T = T, kwargs...)) |> sum
+                            loss(k_solve, rate_constant(V, model; a_r=a_r_solve, a_o=a_o_solve, T = T, kwargs...)) |> sum
                         end
                     end
                     F .= y
@@ -107,7 +122,7 @@ function overpotential(k, model::KineticModel; a_r=1.0, a_o=1.0, guess = 0.1, T 
             @warn "Overpotential fit not fully converged for $k...you may have fed in an unreachable reaction rate!"
         end
         sol = Vs.zero
-        sol_return[inds_keep] = sol
+        sol_return[inds_solve] = sol
     end
 
     # did we skip any solves? If so, we need to actually do the linearized solve and reconstruct the output array
@@ -115,7 +130,7 @@ function overpotential(k, model::KineticModel; a_r=1.0, a_o=1.0, guess = 0.1, T 
         k_lin = k_check[inds_linearize]
         slope = Zygote.jacobian(0) do V
             Zygote.forwarddiff(V) do V
-                rate_constant(V, model; a_o=a_o, a_r=a_r, T=T, kwargs...)
+                rate_constant(V, model; a_o=a_o_check[inds_linearize], a_r=a_r_check[inds_linearize], T=T, kwargs...)
             end
         end[1]
         sol_return[inds_linearize] = k_lin ./ slope

--- a/src/kinetic_models/AsymptoticMarcusHushChidsey.jl
+++ b/src/kinetic_models/AsymptoticMarcusHushChidsey.jl
@@ -10,8 +10,8 @@ struct AsymptoticMarcusHushChidsey{T} <: NonIntegralModel{T}
     A::T
     λ::T
     function AsymptoticMarcusHushChidsey(A, λ)
-        ps = consistent_params(Float32.(A), Float32.(λ))
-        new{typeof(ps[1])}(ps...)
+        ps = consistent_params(A, λ)
+        new{typeof(ps[2])}(ps...)
     end
 end
 

--- a/src/kinetic_models/ButlerVolmer.jl
+++ b/src/kinetic_models/ButlerVolmer.jl
@@ -11,8 +11,8 @@ struct ButlerVolmer{T} <: NonIntegralModel{T}
     α::T
     function ButlerVolmer(A, α)
         @assert all(α .<= 1.0 .&& α .>=0.0) "Electron transfer coefficient must be in [0,1]"
-        ps = consistent_params(Float32.(A), Float32.(α))
-        new{typeof(ps[1])}(ps...)
+        ps = consistent_params(A, α)
+        new{typeof(ps[2])}(ps...)
     end
 end
 

--- a/src/kinetic_models/Marcus.jl
+++ b/src/kinetic_models/Marcus.jl
@@ -10,8 +10,8 @@ struct Marcus{T} <: NonIntegralModel{T}
     A::T
     λ::T
     function Marcus(A, λ)
-        ps = consistent_params(Float32.(A), Float32.(λ))
-        new{typeof(ps[1])}(ps...)
+        ps = consistent_params(A, λ)
+        new{typeof(ps[2])}(ps...)
     end
 end
 

--- a/src/kinetic_models/MarcusHushChidsey.jl
+++ b/src/kinetic_models/MarcusHushChidsey.jl
@@ -14,8 +14,8 @@ struct MarcusHushChidsey{T} <: IntegralModel{T}
     λ::T
     average_dos::T
     function MarcusHushChidsey(A, λ, average_dos)
-        ps = consistent_params(Float32.(A), Float32.(λ), Float32.(average_dos))
-        new{typeof(ps[1])}(ps...)
+        ps = consistent_params(A, λ, average_dos)
+        new{typeof(ps[2])}(ps...)
     end
 end
 

--- a/src/kinetic_models/MarcusHushChidseyDOS.jl
+++ b/src/kinetic_models/MarcusHushChidseyDOS.jl
@@ -13,8 +13,8 @@ struct MarcusHushChidseyDOS{T} <: IntegralModel{T}
     λ::T
     dos::DOSData
     function MarcusHushChidseyDOS(A, λ, dos)
-        ps = consistent_params(Float32.(A), Float32.(λ))
-        new{typeof(ps[1])}(ps..., dos)
+        ps = consistent_params(A, λ)
+        new{typeof(ps[2])}(ps..., dos)
     end
 end
 

--- a/src/phase_diagrams.jl
+++ b/src/phase_diagrams.jl
@@ -11,7 +11,7 @@ const Ω_default = 0.1
 
 # our familiar thermodynamic functions
 h(x;Ω=Ω_default) = @. x*(1-x)*Ω # enthalpy of mixing
-s(x) = @. -kB*(x*log(x+eps(Float32)) + (1-x)*log(1-x+eps(Float32))) # entropy per particle...added epsilons in the hopes that things will be less obnoxious at the edges
+s(x) = @. -kB*(x*log(x+eps(typeof(x))) + (1-x)*log(1-x+eps(typeof(x)))) # entropy per particle...added epsilons in the hopes that things will be less obnoxious at the edges
 g_thermo(x; Ω=Ω_default, muoA=muoA_default, muoB=muoB_default, T=room_T) = @. h(x;Ω) - T*s(x)+ muoA*(1-x) + muoB*x # Gibbs free energy per particle
 μ_thermo(x; Ω=Ω_default, muoA=muoA_default, muoB=muoB_default, T=room_T) = @. (1-2*x)*Ω + kB*T*log(x/(1-x)) + muoB-muoA # chemical potential
 
@@ -60,7 +60,7 @@ end
 function common_tangent(x::Vector, I, km::KineticModel; kwargs...)
     g = g_kinetic(I, km; kwargs...)
     µ = µ_kinetic(I, km; kwargs...)
-    [(g(x[2]) - g(x[1]))/(x[2] - x[1]) .- μ(x[1]), μ(x[2])-μ(x[1])]
+    [(g(x[2]) - g(x[1]))/(x[2] - x[1]) .- 0.5*(μ(x[1])+µ(x[2])), μ(x[2])-μ(x[1])]
 end
 
 # TODO: see if we can speed this up with gradients? And/or if it's even needed for integral cases

--- a/src/utils/dos.jl
+++ b/src/utils/dos.jl
@@ -18,9 +18,9 @@ Struct for storing density of states (DOS) information. Can be constructed from 
 """
 struct DOSData
     interp_func
-    average_value::Float32
-    E_min::Float32
-    E_max::Float32
+    average_value
+    E_min
+    E_max
 end
 
 DOSData(dos_file; Ef=0, cut_energy=false) = DOSData(get_dos(dos_file; Ef, cut_energy)...)
@@ -49,7 +49,7 @@ function get_dos(dos_file::String; kwargs...)
     #     x = readdlm(dos_file, Float32, skipstart=1)
     #     x
     # end
-    dos_data = readdlm(dos_file, Float32, skipstart=1)
+    dos_data = readdlm(dos_file, skipstart=1)
     get_dos(dos_data; kwargs...)
 end
 function get_dos(dd::Matrix; Ef=0, cut_energy=false)


### PR DESCRIPTION
A variety of numerical tweaks to make things a bit more stable, particularly when calling `overpotential` for very small currents...
- stop forcing things onto 32-bit arithmetic
- in the first term of the check in `common_tangent`, compare to the average of the two chemical potentials
- and the pièce de résistance: just linearize the solve at small currents! Introduced a parameter `lin_thresh` that controls when this happens – if the `k` value being solved for is less than `lin_thresh` multiplied by the rate at the thermal voltage, then just solve a linear equation with a slope from AD rather than doing the full nonlinear solve
- also added some tweaks in `_get_guess` that uniformizes lengths of vectors, which should hopefully avoid weird zipping errors

A lot of tests should still be added for this stuff, but I'm probably going to merge this before I add them for easier dependency management in the environment for the manuscript...